### PR TITLE
Dark mode

### DIFF
--- a/src/Components/Inventory.tsx
+++ b/src/Components/Inventory.tsx
@@ -35,7 +35,7 @@ function Inventory({ProfileHandler,
                 currentPage='Inventory'
             />;
 
-            <div className="white-half" style={{ width: '80%', height: '100%', backgroundColor: 'white', position: 'absolute', left: '20%' }}>
+            <div className="white-half">
                 <Navigation 
                     username="Kelvin"
                     redirects={

--- a/src/Components/LogIn.tsx
+++ b/src/Components/LogIn.tsx
@@ -17,7 +17,7 @@ function LogIn({backToHomeHandler}: Props) {
                 <img id="wireframe" src={HumaaansWireframe} alt="login image" />
             </div>
 
-            <div className="white-half">
+            <div className="login-white-half">
                 <button id='back' onClick={backToHomeHandler}>
                     &lt; Back
                 </button>

--- a/src/Components/Profile.tsx
+++ b/src/Components/Profile.tsx
@@ -4,6 +4,7 @@ import '../Styles/Profile.modules.css';
 import edit_icon from '../Images/Edit_icon.png'
 import NavigationBar from './utils/BlueNavBar'
 import Navigation from './utils/Navigation';
+import { useDarkMode } from './utils/DarkMode';
 
 interface Props {
     getStartedHandler: () => void;
@@ -32,7 +33,7 @@ function Profile({ProfileHandler,
                 currentPage='Profile'
             />;
 
-            <div className="white-half" style={{ width: '80%', height: '100%', backgroundColor: 'white', position: 'absolute', left: '20%' }}>
+            <div className="white-half">
                 <Navigation 
                     username="Kelvin"
                     redirects={

--- a/src/Components/utils/DarkMode.tsx
+++ b/src/Components/utils/DarkMode.tsx
@@ -25,6 +25,12 @@ export const DarkModeProvider: React.FC<{ children: ReactNode }> = ({ children }
     const darkModeQuery = window.matchMedia('(prefers-color-scheme: dark)');
     darkModeQuery.addEventListener('change', updateDarkMode);
 
+    if (prefersDarkMode) {
+      document.body.classList.add('dark-mode');
+    } else {
+      document.body.classList.remove('dark-mode');
+    }
+    
     return () => {
       darkModeQuery.removeEventListener('change', updateDarkMode);
     };

--- a/src/Styles/AboutUs.modules.css
+++ b/src/Styles/AboutUs.modules.css
@@ -2,6 +2,7 @@ body {
     margin: 0;
     padding: 0;
     overflow-x: hidden;
+    background-color: white;
 }
 
 #top-white-section {

--- a/src/Styles/AboutUs.modules.css
+++ b/src/Styles/AboutUs.modules.css
@@ -5,6 +5,13 @@ body {
     background-color: white;
 }
 
+body.dark-mode {
+    margin: 0;
+    padding: 0;
+    overflow-x: hidden;
+    background-color: #303030;
+}
+
 #top-white-section {
     height: 100vh;
     background-color: white;

--- a/src/Styles/ContactUs.modules.css
+++ b/src/Styles/ContactUs.modules.css
@@ -10,6 +10,10 @@
     line-height: 43.36px;
 }
 
+.dark-theme #contact-us {
+    color: #ffffff;
+}
+
 #website-title-cu {
     position: absolute;
     margin-left: 5%;
@@ -19,6 +23,11 @@
     font-weight: 600;
 
 }
+
+.dark-theme #website-title-cu {
+    color: #ffffff;
+}
+
 #words {
     width: 658px;
     top: 180px;
@@ -28,6 +37,10 @@
     color: #000000;
     font-size: 20px;
     text-align: left;
+}
+
+.dark-theme #words {
+    color: #F0EFEF;
 }
 
 #talk-to-us form {

--- a/src/Styles/FAQ.modules.css
+++ b/src/Styles/FAQ.modules.css
@@ -20,6 +20,11 @@
     line-height: 43.36px;
     transform: translate(-30%);
 }
+
+.dark-theme #page-title {
+    color: #ffffff;
+}
+
 #homeOffice {
     box-sizing: border-box;
     width: 569px;
@@ -46,6 +51,11 @@
         display: none;
     }
 }
+
 #faqBlock {
     padding: 30px;
+}
+
+.dark-theme #faqBlock {
+    color: #ffffff;
 }

--- a/src/Styles/Home.modules.css
+++ b/src/Styles/Home.modules.css
@@ -16,7 +16,6 @@
 }
 
 h1 {
-
     width: 658px;
     height: 322px;
     top: 152px;
@@ -29,11 +28,11 @@ h1 {
     line-height: 75px;
     letter-spacing: 200;
     text-align: left;
-
-
 }
 
-
+.dark-theme h1 {
+    color: #ffffff;
+}
 
 #intro {
     width: 658px;
@@ -44,7 +43,10 @@ h1 {
     color: #000000;
     font-size: 25px;
     text-align: left;
+}
 
+.dark-theme #intro {
+    color: #F0EFEF;
 }
 
 #get-started {
@@ -56,58 +58,6 @@ h1 {
     width: 162.43px;
     height: 44px;
 }
-
-/* #aboutus-button {
-    background-color: white;
-    color: black;
-    border: none;
-    font-size: 16px;
-    padding-left: 55px;
-    padding-top: 30px;
-    padding-bottom: 30px;
-    margin-left: 70%
-}
-#contact-button {
-    background-color: white;
-    color: black;
-    border: none;
-    font-size: 16px;
-    padding-left: 55px;
-    padding-top: 30px;
-    padding-bottom: 30px;
-    margin-left: 80%
-}
-
-
-#FAQ-button {
-    background-color: white;
-    color: black;
-    border: none;
-    font-size: 16px;
-    padding-left: 55px;
-    padding-top: 30px;
-    padding-bottom: 30px;
-    margin-left: 90%
-} */
-/* 
-#buttons {
-    display: flex;
-    justify-content: flex-end;
-    padding: 10px;
-    margin-top: -15px; /* Shift buttons up 
-    margin-right: 8%;
-} 
-/* .info-button {
-    background-color: white;
-    color: black;
-    border: none;
-    font-size: 16px;
-    padding-left: 55px;
-    padding-top: 30px;
-    padding-bottom: 30px;
-    margin-left: 90% 
-    margin-left: 10px;
-} */
 
 #icon {
     /* float: right; */

--- a/src/Styles/Inventory.modules.css
+++ b/src/Styles/Inventory.modules.css
@@ -91,6 +91,9 @@
     border-radius: 20px;
 }
 
+.dark-theme .collection-item {
+    background: #474747;
+}
 
 .view-text {
     position: absolute;
@@ -109,6 +112,10 @@
     background-color: transparent;
 }
 
+.dark-theme .view-text  {
+    color: white;
+}
+
 .name-text {
     position: absolute;
     left: 0;
@@ -124,6 +131,10 @@
     color: #000000;
 }
 
+.dark-theme .name-text  {
+    color: white;
+}
+
 .collection-status {
     position: absolute;
     left: 0;
@@ -137,6 +148,10 @@
     line-height: 24px;
     text-align: center;  
     color: #000000;
+}
+
+.dark-theme .collection-status {
+    color: white;
 }
 
 .collection-item img {

--- a/src/Styles/Inventory.modules.css
+++ b/src/Styles/Inventory.modules.css
@@ -9,6 +9,10 @@
     border-radius: 20px;
 }
 
+.dark-theme #top-area {
+    background: #474747;
+}
+
 #inventory-title2 {
     position: absolute;
     width: 27%; /* Adjusted width */
@@ -21,6 +25,10 @@
     font-size: 24px;
     line-height: 22px;
     color: #000000;
+}
+
+.dark-theme #inventory-title2 {
+    color: white;
 }
 
 #collection-progress {
@@ -37,6 +45,10 @@
     font-weight: 600;
     font-size: 20px;
     line-height: 24px;
+}
+
+.dark-theme #collection-progress {
+    background: #1a1a1a;
 }
 
 #collection-progress .progress-text {

--- a/src/Styles/Navigation.css
+++ b/src/Styles/Navigation.css
@@ -18,6 +18,10 @@
     background-color: transparent;
 }
 
+.dark-theme #page-title-button {
+    color: white;
+}
+
 #top-buttons {
     position: absolute;
     display: flex;
@@ -39,6 +43,11 @@
     margin-left: 3%; 
     cursor: pointer;
 }
+
+.dark-theme .info-button {
+    color: white;
+}
+
 
 #red-name-button {
     position: absolute;

--- a/src/Styles/Profile.modules.css
+++ b/src/Styles/Profile.modules.css
@@ -7,6 +7,10 @@
     background: #F0EFEF;
 }
 
+.dark-theme #profile-background {
+    background: #474747;
+}
+
 #avatar {
     position: absolute;
     width: 13%;
@@ -15,6 +19,10 @@
     top: 35%;
     border-radius: 50%;
     background: #D9D9D9;
+}
+
+.dark-theme #avatar {
+    background: #1a1a1a;
 }
 
 
@@ -35,6 +43,10 @@
     color: #3127A0;
 }
 
+.dark-theme #username {
+    color: white;
+}
+
 
 #bio {
     position: absolute;
@@ -50,6 +62,10 @@
     line-height: 110%;
 
     color: #000000;
+}
+
+.dark-theme #bio {
+    color: #F0EFEF;
 }
 
 
@@ -80,6 +96,12 @@
     height: 20px; /* Adjust the height of the icon */
 }
 
+.dark-theme #edit-button {
+    background: transparent;
+    color: #F0EFEF;
+}
+
+
 #info-slot-topleft {
     position: absolute;
     width: 38%;
@@ -88,6 +110,10 @@
     top: 47%;
     background: #F0EFEF;
     border-radius: 30px;
+}
+
+.dark-theme #info-slot-topleft {
+    background: #474747;
 }
 
 #info-slot-topright {
@@ -100,6 +126,10 @@
     border-radius: 30px;
 }
 
+.dark-theme #info-slot-topright {
+    background: #474747;
+}
+
 #info-slot-bottomleft {
     position: absolute;
     width: 38%;
@@ -110,6 +140,10 @@
     border-radius: 30px;
 }
 
+.dark-theme #info-slot-bottomleft {
+    background: #474747;
+}
+
 #info-slot-bottomright {
     position: absolute;
     width: 38%;
@@ -118,6 +152,10 @@
     top: calc(47% + 21% + 6%);
     background: #F0EFEF;
     border-radius: 30px;
+}
+
+.dark-theme #info-slot-bottomright {
+    background: #474747;
 }
 
 #info-slot-title {
@@ -135,6 +173,10 @@
 
     color: #000000;
 }
+.dark-theme #info-slot-title {
+    color: #F0EFEF;
+}
+
 
 #info-slot-icon {
     position: absolute;
@@ -145,6 +187,10 @@
 
     background: #D9D9D9;
     border-radius: 20px;
+}
+
+.dark-theme #info-slot-icon {
+    background: #1a1a1a;
 }
 
 #info-slot-stats {
@@ -161,5 +207,9 @@
     line-height: 70%;
     white-space: nowrap;
     color: #3127A0;
+}
+
+.dark-theme #info-slot-stats {
+    color: #F0EFEF;
 }
 

--- a/src/Styles/Sidebar.css
+++ b/src/Styles/Sidebar.css
@@ -11,6 +11,19 @@
     background-color: #1A1A1A;
 }
 
+.white-half {
+    width: 80%;
+    height: 100%;
+    background-color: white;
+    position: absolute;
+    left: 20%;
+    top: 0;
+}
+
+.dark-theme .white-half {
+    background-color: #303030;
+}
+
 #website-title {
     position: absolute;
     left: 10.46%;


### PR DESCRIPTION
Added body for dark mode wrapper and everything is now available with dark-mode besides login, about us and progress page. For those pages, the author of the page need to fix it first in order for me to implement dark mode.

login page to fix: There are so many dependencies for variable name
progress page: There is an extra white cover above the background, and lesson's are not lining up
about us page: This page have two layers, the bottom layer is an introduction to staffs, and they covered it with a white square, and above that they place the about us page. 